### PR TITLE
Add null check for target

### DIFF
--- a/lib/adl/adl-formatter.js
+++ b/lib/adl/adl-formatter.js
@@ -285,7 +285,7 @@ class DataElementADLFormatter {
               const target = this.specs.dataElements.findByIdentifier(targetIdentifier).value;
               let valueCstString;
 
-              if (target.constructor.name === 'ChoiceValue') {
+              if (target && target.constructor.name === 'ChoiceValue') {
                 valueCstString = `valueChoice${valueCst.constraintDef.name} matches { ${valueCst.toString()} }`;
               } else {
                 valueCstString = `value matches { ${valueCst.toString()} }`;

--- a/lib/adl/adl-formatter.js
+++ b/lib/adl/adl-formatter.js
@@ -282,13 +282,15 @@ class DataElementADLFormatter {
             if (typeConstraints.length > 1 && typeConstraints.some(tc => tc.onValue && tc.path.length == 1)) {
               const valueCst = typeConstraints.find(tc => tc.onValue && tc.path.length == 1);
               const targetIdentifier = valueCst.constrainedTerm.sourceCimpl.identifier;
-              const target = this.specs.dataElements.findByIdentifier(targetIdentifier).value;
+              const target = this.specs.dataElements.findByIdentifier(targetIdentifier);
               let valueCstString;
 
-              if (target && target.constructor.name === 'ChoiceValue') {
-                valueCstString = `valueChoice${valueCst.constraintDef.name} matches { ${valueCst.toString()} }`;
-              } else {
-                valueCstString = `value matches { ${valueCst.toString()} }`;
+              if (target.value) {
+                if (target.value.constructor.name === 'ChoiceValue') {
+                  valueCstString = `valueChoice${valueCst.constraintDef.name} matches { ${valueCst.toString()} }`;
+                } else {
+                  valueCstString = `value matches { ${valueCst.toString()} }`;
+                }
               }
 
               cstString = formatMatchStatement(cstString, valueCstString).join('\n\t');


### PR DESCRIPTION
There was a fatal error in ADL export when using the default config on the `shr_spec`'s `shimi` branch. The fix ended up being a very simple `null` check. 

I do not believe this is a symptom of a larger problem. This error occurs because a desired data element found by the identifier in a value constraint does not have a `.value` field. I think that this is really was just a missed `null` check error, since this field is not directly used anywhere in this context other than to check if the constraint is a `ChoiceValue`. 